### PR TITLE
Updated JCB card schema with new length

### DIFF
--- a/src/Cards/Jcb.php
+++ b/src/Cards/Jcb.php
@@ -32,7 +32,7 @@ class Jcb extends Card implements CreditCard
      *
      * @var array
      */
-    protected $number_length = [16];
+    protected $number_length = [16, 17, 18, 19];
 
     /**
      * CVC code length's.


### PR DESCRIPTION
[As of February 2017, JCB cards can be 16-19 digits long](https://www.discovernetwork.com/downloads/IPP_VAR_Compliance.pdf). This updates the validation to use the new lengths.