### PR TITLE
Extend number length for american express

### DIFF
--- a/src/Cards/AmericanExpress.php
+++ b/src/Cards/AmericanExpress.php
@@ -39,7 +39,7 @@ class AmericanExpress extends Card implements CreditCard
      *
      * @var array
      */
-    protected $number_length = [15];
+    protected $number_length = [15, 16];
 
     /**
      * CVC code length's.

--- a/tests/Unit/Cards/AmericanExpressTest.php
+++ b/tests/Unit/Cards/AmericanExpressTest.php
@@ -115,6 +115,7 @@ class AmericanExpressTest extends BaseCardTests
             '344566883297843',
             '379811393604866',
             '378167408666270',
+            '3455555555555504',
         ]);
     }
 


### PR DESCRIPTION
American Express card can also be 16 digits long, please test with these card details:

Card Number: 3455555555555504
CV2/CVV: 1234