### PR TITLE
Allow null value for card_number

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -40,23 +40,23 @@ class Factory
     ];
 
     /**
-     * @param string $card_number
+     * @param string|mixed $card_number
      *
      * @return \LVR\CreditCard\Cards\Card
      * @throws \LVR\CreditCard\Exceptions\CreditCardException
      */
-    public static function makeFromNumber(string $card_number)
+    public static function makeFromNumber($card_number)
     {
         return self::determineCardByNumber($card_number);
     }
 
     /**
-     * @param string $card_number
+     * @param string|mixed $card_number
      *
      * @return mixed
      * @throws \LVR\CreditCard\Exceptions\CreditCardException
      */
-    protected static function determineCardByNumber(string $card_number)
+    protected static function determineCardByNumber($card_number)
     {
         foreach (self::$available_cards as $card) {
             if (preg_match($card::$pattern, $card_number)) {

--- a/tests/Unit/CardTest.php
+++ b/tests/Unit/CardTest.php
@@ -10,12 +10,17 @@ use LVR\CreditCard\Tests\TestCase;
 
 class CardTest extends TestCase
 {
-    /** @test **/
-    public function it_expects_card_number()
+    /** @test @dataProvider badStrings **/
+    public function it_expects_card_number($input)
     {
         $this->expectException(CreditCardException::class);
 
-        Factory::makeFromNumber('');
+        Factory::makeFromNumber($input);
+    }
+    
+    public function badStrings()
+    {
+        return ['empty string' => [['']], 'null' => [[null]]];
     }
 
     /** @test **/

--- a/tests/Unit/CardTest.php
+++ b/tests/Unit/CardTest.php
@@ -20,7 +20,7 @@ class CardTest extends TestCase
     
     public function badStrings()
     {
-        return ['empty string' => [['']], 'null' => [[null]]];
+        return ['empty string' => [''], 'null' => [null]];
     }
 
     /** @test **/

--- a/tests/Unit/CardTest.php
+++ b/tests/Unit/CardTest.php
@@ -17,7 +17,7 @@ class CardTest extends TestCase
 
         Factory::makeFromNumber($input);
     }
-    
+
     public function badStrings()
     {
         return ['empty string' => [''], 'null' => [null]];


### PR DESCRIPTION
It's highly possible that the credit card number field will be null, since after all we are dealing with request validation. Currently, although the `CardCvc` constructor allows any type, `Factory::makeFromNumber` (called inside `CardCvc::__construct`) expects a string. This causes a `TypeError` at runtime if the user leaves the credit card number field blank, since Laravel converts empty strings to null.

Fixes #24.