### PR TITLE
American Express 4-digit CVV

### DIFF
--- a/src/Cards/AmericanExpress.php
+++ b/src/Cards/AmericanExpress.php
@@ -46,7 +46,7 @@ class AmericanExpress extends Card implements CreditCard
      *
      * @var array
      */
-    protected $cvc_length = [3, 4];
+    protected $cvc_length = [4];
 
     /**
      * Test cvc code checksum against Luhn algorithm.

--- a/tests/Unit/CardCvcTest.php
+++ b/tests/Unit/CardCvcTest.php
@@ -17,6 +17,9 @@ class CardCvcTest extends TestCase
         $this->assertTrue($this->validator('243')->passes());
         $this->assertTrue($this->validator('1234')->passes());
 
+        $this->assertTrue($this->validator('1234', new AmericanExpressTest)->passes());
+        $this->assertFalse($this->validator('243', new AmericanExpressTest)->passes()); // American Express supports only 4 digits
+
         $this->assertTrue($this->validator('243', new VisaTest)->passes());
         $this->assertTrue($this->validator('1234', new VisaTest)->fails()); // Visa supports only 3 digits
 


### PR DESCRIPTION
American Express cards only support 4-digit security codes.

> Your credit card CVV code may not be in the same place on every credit card. If you have an American Express® Card, you will find the **four-digit** credit card CVV on the front.

Source: https://www.americanexpress.com/ca/en/articles/life-with-amex/learn/what-is-credit-card-cvv/

This PR makes the AmericanExpress cards explicitly have 4-digit CVC and adds 2 test assertions.