### PR TITLE
Fix brand variable for Visa Electron

### DIFF
--- a/src/Cards/VisaElectron.php
+++ b/src/Cards/VisaElectron.php
@@ -32,7 +32,7 @@ class VisaElectron extends Card implements CreditCard
      *
      * @var string
      */
-    protected $cleanName = 'Visa Electron';
+    protected $brand = 'Visa Electron';
 
     /**
      * Card number length's.


### PR DESCRIPTION
The VisaElectron class doesn't have a brand.
Here we rename the cleanName variable to brand variable